### PR TITLE
Get it to run on El Capitan and iOS 9

### DIFF
--- a/Source/Mac/MultipeerClient.swift
+++ b/Source/Mac/MultipeerClient.swift
@@ -68,7 +68,7 @@ final class MultipeerClient: NSObject, MCNearbyServiceAdvertiserDelegate, MCSess
     // MARK: MCNearbyServiceAdvertiserDelegate
 
     func advertiser(advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: NSData?, invitationHandler: (Bool, MCSession) -> Void)  {
-        session = MCSession(peer: localPeerID, securityIdentity: nil, encryptionPreference: .None)
+        session = MCSession(peer: localPeerID, securityIdentity: nil, encryptionPreference: .Required)
         guard let session = session else { return }
         session.delegate = self
         invitationHandler(true, session)
@@ -94,7 +94,7 @@ final class MultipeerClient: NSObject, MCNearbyServiceAdvertiserDelegate, MCSess
 
     }
 
-    func session(session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, atURL localURL: NSURL, withError error: NSError) {
+    func session(session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, atURL localURL: NSURL, withError error: NSError?) {
 
     }
 

--- a/Source/iOS/Info.plist
+++ b/Source/iOS/Info.plist
@@ -30,7 +30,5 @@
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array/>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 </dict>
 </plist>

--- a/Source/iOS/ViewController.swift
+++ b/Source/iOS/ViewController.swift
@@ -21,7 +21,7 @@ final class ViewController: UICollectionViewController {
                 self.collectionView?.contentOffset.x = 0
                 self.collectionView?.reloadData()
                 // Trigger state change block
-                self.multipeerClient.onStateChange??(state: self.multipeerClient.state, peerID: MCPeerID())
+                self.multipeerClient.onStateChange??(state: self.multipeerClient.state, peerID: MCPeerID(displayName: "placeholder"))
             }
         }
     }


### PR DESCRIPTION
A few exciting parts to this.

The obvious one is the missing question mark. Xcode was even kind enough to tell me what to do.

Once I fixed that, I was getting this bizarre situation where the phone was inviting and the computer was accepting, but nothing was happening. Looking at the [security changelog for El Capitan](https://support.apple.com/en-us/HT205267), I found this:

> **Multipeer Connectivity**
>
> An issue existed in convenience initializer handling in which encryption could be actively downgraded to a non-encrypted session. This issue was addressed by changing the convenience initializer to require encryption.

Apparently this causes `encryptionPreference: .None` to fail silently — brilliant engineering. Changing it to `.Required` makes it work!

_Then_, I was getting a runtime error in the empty `MCPeerID()` constructor, so I threw a placeholder `displayName` in there like it seemed to want, and that worked.

Finally and least interesting, I was getting the weird errors described [here](https://forums.developer.apple.com/thread/13683), so I did what they suggested and took `UIViewControllerBasedStatusBarAppearance` out of the config.