### PR TITLE
Downsize notesView's fontSize if needed.

### DIFF
--- a/Source/iOS/Cell.swift
+++ b/Source/iOS/Cell.swift
@@ -11,6 +11,8 @@ import Cartography
 
 private var gNotesHidden = true
 
+private let gDefaultNotesFont = UIFont.systemFontOfSize(30)
+
 final class Cell: UICollectionViewCell {
 
     // MARK: Properties
@@ -58,7 +60,7 @@ final class Cell: UICollectionViewCell {
     }
 
     private func setupNotesView() {
-        notesView.font = UIFont.systemFontOfSize(30)
+        notesView.font = gDefaultNotesFont
         notesView.backgroundColor = UIColor.clearColor()
         notesView.textColor = UIColor.whiteColor()
         notesView.userInteractionEnabled = false
@@ -103,5 +105,6 @@ final class Cell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         resetHidden()
+        notesView.font = gDefaultNotesFont
     }
 }

--- a/Source/iOS/ViewController.swift
+++ b/Source/iOS/ViewController.swift
@@ -168,6 +168,8 @@ final class ViewController: UICollectionViewController, WCSessionDelegate {
             forIndexPath: indexPath) as! Cell // swiftlint:disable:this force_cast
         cell.imageView.image = slides?[indexPath.item].image
         cell.notesView.text = slides?[indexPath.item].notes
+        cell.notesView.downsizeFontIfNeeded()
+
         if indexPath.item + 1 < slides?.count {
             cell.nextSlideView.image = slides?[indexPath.item + 1].image
         } else {
@@ -205,4 +207,19 @@ final class ViewController: UICollectionViewController, WCSessionDelegate {
         }
         setCollectionViewItemSize(size)
     }
+}
+
+extension UITextView {
+
+    private func downsizeFontIfNeeded() {
+        if (text.isEmpty || CGSizeEqualToSize(bounds.size, CGSize.zero)) {
+            return
+        }
+
+        while (sizeThatFits(CGSize(width: frame.size.width, height: CGFloat(FLT_MAX))).height
+            > frame.size.height) {
+            font = font!.fontWithSize(font!.pointSize - 1)
+        }
+    }
+
 }


### PR DESCRIPTION
This is a hotfix for notes not to be cut off when it is too long.
This is useful especially for my _try!_ presentation :blush: